### PR TITLE
Upgrading IntelliJ to 2022.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ to 2022.2.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'sample-intellij-plugin'
 # SemVer format -> https://semver.org
-pluginVersion = 0.2.9
+pluginVersion = 0.2.10
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 0.2.9
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2022.2
+pluginVerifierIdeVersions = 2022.2.1
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
@@ -22,7 +22,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2022.2
+platformVersion = 2022.2.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

    # Upgrading IntelliJ to 2022.2.1
    
    You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-264/IntelliJ-IDEA-202221-222373954-build-Release-Notes
    
    # What's New?
    IntelliJ IDEA 2022.2.1 is out! 
<ul> 
 <li>Fixed the issue causing incorrect preview rendering of Mermaid diagrams containing non-ASCII characters [<a href="https://youtrack.jetbrains.com/issue/IDEA-289431/">IDEA-289431</a>].</li> 
 <li>Fixed issues with Terminal tab names [<a href="https://youtrack.jetbrains.com/issue/IDEA-297207/Terminal-tab-name-resets-when-activating">IDEA-297207</a>], <a href="https://youtrack.jetbrains.com/issue/IDEA-290225/">IDEA-290225</a>].</li> 
 <li>Fixed the issue causing code completion to malfunction when working with WSL [<a href="https://youtrack.jetbrains.com/issue/IDEA-297761">IDEA-297761</a>].</li> 
 <li>The <em>@SpringJUnitConfig </em>and <em>@SpringJUnitWebConfig</em> annotations are again properly supported by the IDE [<a href="https://youtrack.jetbrains.com/issue/IDEA-166549/">IDEA-166549</a>].</li> 
</ul> For more details, refer to this 
<a href="https://blog.jetbrains.com/idea/2022/08/intellij-idea-2022-2-1/">blog post</a>.
    