### PR TITLE
Upgrading IntelliJ from 2022.2.0 to 2022.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2022.2 to 2022.2.4
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'sample-intellij-plugin'
 # SemVer format -> https://semver.org
-pluginVersion = 0.2.9
+pluginVersion = 0.2.10
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 0.2.9
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2022.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2022.2.4,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 
@@ -24,7 +24,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2022.2
+platformVersion = 2022.2.4
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2022.2.0 to 2022.2.4

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661403/IntelliJ-IDEA-2022.2.4-222.4459.24-build-Release-Notes

# What's New?
IntelliJ IDEA 2022.2.4 Is Out! 
<ul> 
 <li>Changing the display layout or waking from sleep mode no longer causes corrupted text or a flashing red screen on macOS <a href="https://youtrack.jetbrains.com/issue/JBR-4864">[JBR-4864]</a>.</li> 
 <li>The screen no longer flickers when working with the IDE in full screen mode on macOS Ventura [<a href="https://youtrack.jetbrains.com/issue/JBR-4959">JBR-4959</a>]. </li> 
</ul> For more details, please refer to this 
<a href="https://blog.jetbrains.com/idea/2022/11/intellij-idea-2022-2-4/">blog post</a>.
    