### PR TITLE
Upgrading IntelliJ from 2022.2.4 to 2022.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2022.2.4 to 2022.3.1
 - Upgrading IntelliJ from 2022.2 to 2022.2.4
 
 ### Deprecated

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'sample-intellij-plugin'
 # SemVer format -> https://semver.org
-pluginVersion = 0.2.10
+pluginVersion = 0.3.0
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 0.2.10
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2022.2.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2022.3.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 
@@ -24,7 +24,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2022.2.4
+platformVersion = 2022.3.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2022.2.4 to 2022.3.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661418/IntelliJ-IDEA-2022.3.1-223.8214.52-build-Release-Notes

# What's New?
IntelliJ IDEA 2022.3.1 is now available! 
<ul> 
 <li>The option to display editor tabs on multiple rows is available in the new UI [<a href="https://youtrack.jetbrains.com/issue/IDEA-295095">IDEA-29509</a>].</li> 
 <li>Actions on Save work as expected again. [<a href="https://youtrack.jetbrains.com/issue/IDEA-307368">IDEA-307368</a>]</li> 
 <li>Opening a project file from an external tool no longer causes the IDE to throw the "Access is allowed from event dispatch thread only" exception. [<a href="https://youtrack.jetbrains.com/issue/IDEA-301392/An-exception-Access-is-allowed-from-event-dispatch-thread-only-while-opening-a-project-file-in-IDEA-from-any-external-tool">IDEA-301392</a>]</li> 
 <li>Excessive CPU usage and IDE freezes that occurred for certain tool window sizes have been fixed. [<a href="https://youtrack.jetbrains.com/issue/IDEA-306642/UI-hangs-when-calling-a-context-menu">IDEA-306642</a>]</li> 
 <li>Double-clicking on the window header maximizes the window size on macOS. [<a href="https://youtrack.jetbrains.com/issue/IDEA-304577/IDEA-window-is-not-maximised-when-double-clicking-empty-area-in-the-window-header">IDEA-304577</a>]</li> 
</ul> For more details, please see this 
<a href="https://blog.jetbrains.com/idea/2022/12/intellij-idea-2022-3-1/">blog post</a>.
    