### PR TITLE
Upgrading IntelliJ from 2024.1 to 2024.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.1 to 2024.1.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'sample-intellij-plugin'
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.0
+pluginVersion = 1.0.1
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -13,7 +13,7 @@ pluginUntilBuild = 241.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.1.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 
@@ -23,7 +23,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.1
+platformVersion = 2024.1.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.1 to 2024.1.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661951/IntelliJ-IDEA-2024.1.1-241.15989.150-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.1.1 is out with the following updates: 
<ul> 
 <li>AI Assistant is now available in IntelliJ IDEA Community Edition.</li> 
 <li>Code validation no longer produces incorrect code highlighting caused by freezes while reevaluating inspections. [<a href="https://youtrack.jetbrains.com/issue/IJPL-28967">IJPL-28967</a>]</li> 
 <li>Gradle project builds no longer fail during testing when the JaCoCo plugin is used. [<a href="https://youtrack.jetbrains.com/issue/IDEA-344011">IDEA-344011</a>]</li> 
 <li>We fixed the issue that caused failures when opening Gradle projects on WSL due to a missing JDK. [<a href="https://youtrack.jetbrains.com/issue/IDEA-329792">IDEA-329792</a>]</li> 
</ul> Get more details in our 
<a href="https://blog.jetbrains.com/idea/2024/04/intellij-idea-2024-1-1/">blog post</a>.
    