### PR TITLE
Upgrading IntelliJ from 2025.3.1 to 2025.3.1-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.3.1 to 2025.3.1-1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ pluginUntilBuild = 253.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.3.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.3.1-1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # TODO(ChrisCarini) - This can be removed once https://youtrack.jetbrains.com/issue/MP-6711 is resolved.
 #  See below for details:
@@ -35,7 +35,7 @@ pluginVerifierMutePluginProblems = TemplateWordInPluginName
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.3.1
+platformVersion = 2025.3.1-1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.3.1 to 2025.3.1-1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662602/IntelliJ-IDEA-2025.3.1.1-253.29346.240-build-Release-Notes

# What's New?
IntelliJ IDEA 2025.3.1.1 is out! This update includes a hotfix for memory leak in large Maven projects and fixes related to project settings behavior when working with WSL. Check out the <a href="https://youtrack.jetbrains.com/articles/IDEA-A-2100662602/IntelliJ-IDEA-2025.3.1.1-253.29346.240-build-Release-Notes">release notes</a> for all the details.
    